### PR TITLE
fixes client thread exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'io.robrichardson.inventorycount'
-version = '1.0.1'
+version = '1.0.2'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/io/robrichardson/inventorycount/InventoryCountPlugin.java
+++ b/src/main/java/io/robrichardson/inventorycount/InventoryCountPlugin.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.events.ItemContainerChanged;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
@@ -26,6 +27,9 @@ public class InventoryCountPlugin extends Plugin
 {
 	@Inject
 	private Client client;
+
+	@Inject
+	private ClientThread clientThread;
 
 	@Inject
 	private InfoBoxManager infoBoxManager;
@@ -109,15 +113,17 @@ public class InventoryCountPlugin extends Plugin
 
 	private void updateOverlays()
 	{
-		String text = String.valueOf(openInventorySpaces());
-		if(config.renderOnInventory())
-		{
-			overlay.setText(text);
-		}
-		else
-		{
-			inventoryCountInfoBox.setText(text);
-		}
+		clientThread.invoke(() -> {
+			String text = String.valueOf(openInventorySpaces());
+			if(config.renderOnInventory())
+			{
+				overlay.setText(text);
+			}
+			else
+			{
+				inventoryCountInfoBox.setText(text);
+			}
+		});
 	}
 
 	private int openInventorySpaces()


### PR DESCRIPTION
Fixed issue where `client.getItemContainer()` call was not being made on the client thread.

@robrichardson13 Could you please take a look at this for me?

Additionally, would you be willing to add me as a contributor to help keep this plugin updated in the future?

https://github.com/runelite/runelite/wiki/Plugin-takeover-policy