### PR TITLE
refactors inventory overlay widget and text component

### DIFF
--- a/src/main/java/io/robrichardson/inventorycount/InventoryCountConfig.java
+++ b/src/main/java/io/robrichardson/inventorycount/InventoryCountConfig.java
@@ -33,7 +33,7 @@ public interface InventoryCountConfig extends Config {
 	@ConfigItem(
 			keyName = "customInventoryOverlayTextColor",
 			name = "Text color",
-			description = "Customize the color of the text for the overlay on the inventory icon",
+			description = "Customize the color of the inventory overlay text",
 			position = 3
 	)
 	default Color customInventoryOverlayTextColor() { return Color.WHITE; }

--- a/src/main/java/io/robrichardson/inventorycount/InventoryCountConfig.java
+++ b/src/main/java/io/robrichardson/inventorycount/InventoryCountConfig.java
@@ -4,6 +4,8 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
+import java.awt.*;
+
 @ConfigGroup(InventoryCountConfig.GROUP)
 public interface InventoryCountConfig extends Config {
 	String GROUP = "InventoryCount";
@@ -11,10 +13,36 @@ public interface InventoryCountConfig extends Config {
 	@ConfigItem(
 			keyName = "renderOnInventory",
 			name = "Render on inventory icon",
-			description = "Disable for infobox, enable for text overlay on inventory icon"
+			description = "Disable for infobox, enable for text overlay on inventory icon",
+			position = 1
 	)
 	default boolean renderOnInventory() {
 		return false;
 	}
 
+	@ConfigItem(
+			keyName = "renderInventoryOverlayTextOutline",
+			name = "Text outline",
+			description = "Adds outline to the inventory overlay text",
+			position = 2
+	)
+	default boolean renderInventoryOverlayTextOutline() {
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "customInventoryOverlayTextColor",
+			name = "Text color",
+			description = "Customize the color of the text for the overlay on the inventory icon",
+			position = 3
+	)
+	default Color customInventoryOverlayTextColor() { return Color.WHITE; }
+
+	@ConfigItem(
+			keyName = "customInventoryOverlayTextPosition",
+			name = "Text position",
+			description = "Configure the position of the inventory overlay text",
+			position = 4
+	)
+    default InventoryOverlayTextPositions inventoryOverlayTextPosition() { return InventoryOverlayTextPositions.Bottom; }
 }

--- a/src/main/java/io/robrichardson/inventorycount/InventoryCountConfig.java
+++ b/src/main/java/io/robrichardson/inventorycount/InventoryCountConfig.java
@@ -8,41 +8,45 @@ import java.awt.*;
 
 @ConfigGroup(InventoryCountConfig.GROUP)
 public interface InventoryCountConfig extends Config {
-	String GROUP = "InventoryCount";
+    String GROUP = "InventoryCount";
 
-	@ConfigItem(
-			keyName = "renderOnInventory",
-			name = "Render on inventory icon",
-			description = "Disable for infobox, enable for text overlay on inventory icon",
-			position = 1
-	)
-	default boolean renderOnInventory() {
-		return false;
-	}
+    @ConfigItem(
+            keyName = "renderOnInventory",
+            name = "Render on inventory icon",
+            description = "Disable for infobox, enable for text overlay on inventory icon",
+            position = 1
+    )
+    default boolean renderOnInventory() {
+        return false;
+    }
 
-	@ConfigItem(
-			keyName = "renderInventoryOverlayTextOutline",
-			name = "Text outline",
-			description = "Adds outline to the inventory overlay text",
-			position = 2
-	)
-	default boolean renderInventoryOverlayTextOutline() {
-		return false;
-	}
+    @ConfigItem(
+            keyName = "renderInventoryOverlayTextOutline",
+            name = "Text outline",
+            description = "Adds an outline to the inventory overlay text",
+            position = 2
+    )
+    default boolean renderInventoryOverlayTextOutline() {
+        return false;
+    }
 
-	@ConfigItem(
-			keyName = "customInventoryOverlayTextColor",
-			name = "Text color",
-			description = "Customize the color of the inventory overlay text",
-			position = 3
-	)
-	default Color customInventoryOverlayTextColor() { return Color.WHITE; }
+    @ConfigItem(
+            keyName = "customInventoryOverlayTextColor",
+            name = "Text color",
+            description = "Customize the color of the inventory overlay text",
+            position = 3
+    )
+    default Color customInventoryOverlayTextColor() {
+        return Color.WHITE;
+    }
 
-	@ConfigItem(
-			keyName = "customInventoryOverlayTextPosition",
-			name = "Text position",
-			description = "Configure the position of the inventory overlay text",
-			position = 4
-	)
-    default InventoryOverlayTextPositions inventoryOverlayTextPosition() { return InventoryOverlayTextPositions.Bottom; }
+    @ConfigItem(
+            keyName = "customInventoryOverlayTextPosition",
+            name = "Text position",
+            description = "Configure the position of the inventory overlay text",
+            position = 4
+    )
+    default InventoryOverlayTextPositions inventoryOverlayTextPosition() {
+        return InventoryOverlayTextPositions.Bottom;
+    }
 }

--- a/src/main/java/io/robrichardson/inventorycount/InventoryCountInfoBox.java
+++ b/src/main/java/io/robrichardson/inventorycount/InventoryCountInfoBox.java
@@ -6,12 +6,10 @@ import net.runelite.client.ui.overlay.infobox.InfoBox;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 
-public class InventoryCountInfoBox extends InfoBox
-{
+public class InventoryCountInfoBox extends InfoBox {
     private String _text;
 
-    InventoryCountInfoBox(BufferedImage image, Plugin plugin)
-    {
+    InventoryCountInfoBox(BufferedImage image, Plugin plugin) {
         super(image, plugin);
         setTooltip("Number of open inventory spaces");
     }
@@ -26,8 +24,7 @@ public class InventoryCountInfoBox extends InfoBox
         return Color.WHITE;
     }
 
-    public void setText(String text)
-    {
+    public void setText(String text) {
         _text = text;
     }
 }

--- a/src/main/java/io/robrichardson/inventorycount/InventoryCountOverlay.java
+++ b/src/main/java/io/robrichardson/inventorycount/InventoryCountOverlay.java
@@ -58,17 +58,29 @@ public class InventoryCountOverlay extends Overlay {
     private Widget getInventoryWidget(Client client) {
         Widget inventoryWidget = client.getWidget(ComponentID.FIXED_VIEWPORT_INVENTORY_TAB);
 
-        if (!client.isResized()) {
-            return inventoryWidget != null && !inventoryWidget.isHidden()
-                    ? inventoryWidget
-                    : null;
+        if (isInventoryWidgetVisible(inventoryWidget)) {
+            return inventoryWidget;
         }
 
-        inventoryWidget = client.getWidget(ComponentID.RESIZABLE_VIEWPORT_INVENTORY_TAB);
+        if (client.isResized()) {
+            inventoryWidget = getResizableInventoryWidget(client);
+        }
 
-        return inventoryWidget != null && !inventoryWidget.isHidden()
-                ? inventoryWidget
-                : client.getWidget(ComponentID.RESIZABLE_VIEWPORT_BOTTOM_LINE_INVENTORY_TAB);
+        return isInventoryWidgetVisible(inventoryWidget) ? inventoryWidget : null;
+    }
+
+    private Widget getResizableInventoryWidget(Client client) {
+        Widget inventoryWidget = client.getWidget(ComponentID.RESIZABLE_VIEWPORT_INVENTORY_TAB);
+
+        if (isInventoryWidgetVisible(inventoryWidget)) {
+            return inventoryWidget;
+        }
+
+        return client.getWidget(ComponentID.RESIZABLE_VIEWPORT_BOTTOM_LINE_INVENTORY_TAB);
+    }
+
+    private boolean isInventoryWidgetVisible(Widget inventoryWidget) {
+        return inventoryWidget != null && !inventoryWidget.isHidden();
     }
 
     private TextComponent getInventoryOverlayText(Graphics2D graphics, Widget inventoryWidget) {

--- a/src/main/java/io/robrichardson/inventorycount/InventoryCountOverlay.java
+++ b/src/main/java/io/robrichardson/inventorycount/InventoryCountOverlay.java
@@ -62,9 +62,7 @@ public class InventoryCountOverlay extends Overlay {
             return inventoryWidget;
         }
 
-        if (client.isResized()) {
-            inventoryWidget = getResizableInventoryWidget(client);
-        }
+        inventoryWidget = getResizableInventoryWidget(client);
 
         return isInventoryWidgetVisible(inventoryWidget) ? inventoryWidget : null;
     }

--- a/src/main/java/io/robrichardson/inventorycount/InventoryCountPlugin.java
+++ b/src/main/java/io/robrichardson/inventorycount/InventoryCountPlugin.java
@@ -115,7 +115,7 @@ public class InventoryCountPlugin extends Plugin
 	{
 		clientThread.invoke(() -> {
 			String text = String.valueOf(openInventorySpaces());
-			if(config.renderOnInventory())
+			if (config.renderOnInventory())
 			{
 				overlay.setText(text);
 			}

--- a/src/main/java/io/robrichardson/inventorycount/InventoryCountPlugin.java
+++ b/src/main/java/io/robrichardson/inventorycount/InventoryCountPlugin.java
@@ -16,130 +16,117 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import net.runelite.client.util.ImageUtil;
+
 import java.awt.image.BufferedImage;
 import java.util.Arrays;
 
 @Slf4j
 @PluginDescriptor(
-		name = "Inventory Count"
+        name = "Inventory Count"
 )
-public class InventoryCountPlugin extends Plugin
-{
-	@Inject
-	private Client client;
+public class InventoryCountPlugin extends Plugin {
+    @Inject
+    private Client client;
 
-	@Inject
-	private ClientThread clientThread;
+    @Inject
+    private ClientThread clientThread;
 
-	@Inject
-	private InfoBoxManager infoBoxManager;
+    @Inject
+    private InfoBoxManager infoBoxManager;
 
-	@Inject
-	private InventoryCountOverlay overlay;
+    @Inject
+    private InventoryCountOverlay overlay;
 
-	@Inject
-	private OverlayManager overlayManager;
+    @Inject
+    private OverlayManager overlayManager;
 
-	@Inject
-	private InventoryCountConfig config;
+    @Inject
+    private InventoryCountConfig config;
 
-	private static final BufferedImage INVENTORY_IMAGE;
+    private static final BufferedImage INVENTORY_IMAGE;
 
-	private static final int INVENTORY_SIZE = 28;
+    private static final int INVENTORY_SIZE = 28;
 
-	@Getter
-	private InventoryCountInfoBox inventoryCountInfoBox;
+    @Getter
+    private InventoryCountInfoBox inventoryCountInfoBox;
 
-	static
-	{
-		INVENTORY_IMAGE = ImageUtil.loadImageResource(InventoryCountPlugin.class, "inventory_icon.png");
-	}
+    static {
+        INVENTORY_IMAGE = ImageUtil.loadImageResource(InventoryCountPlugin.class, "inventory_icon.png");
+    }
 
-	@Override
-	protected void startUp() throws Exception
-	{
-		if (config.renderOnInventory())  {
-			overlayManager.add(overlay);
-			updateOverlays();
-		} else {
-			addInfoBox();
-		}
-	}
+    @Override
+    protected void startUp() throws Exception {
+        if (config.renderOnInventory()) {
+            overlayManager.add(overlay);
+            updateOverlays();
+        } else {
+            addInfoBox();
+        }
+    }
 
-	@Override
-	protected void shutDown() throws Exception
-	{
-		if (config.renderOnInventory())  {
-			overlayManager.remove(overlay);
-		} else {
-			removeInfoBox();
-		}
-	}
+    @Override
+    protected void shutDown() throws Exception {
+        if (config.renderOnInventory()) {
+            overlayManager.remove(overlay);
+        } else {
+            removeInfoBox();
+        }
+    }
 
-	@Subscribe
-	public void onConfigChanged(ConfigChanged event) {
-		if (!InventoryCountConfig.GROUP.equals(event.getGroup())) return;
+    @Subscribe
+    public void onConfigChanged(ConfigChanged event) {
+        if (!InventoryCountConfig.GROUP.equals(event.getGroup())) return;
 
-		if ("renderOnInventory".equals(event.getKey())) {
-			if (config.renderOnInventory()) {
-				removeInfoBox();
-				overlayManager.add(overlay);
-				updateOverlays();
-			} else {
-				overlayManager.remove(overlay);
-				addInfoBox();
-			}
-		}
-	}
+        if ("renderOnInventory".equals(event.getKey())) {
+            if (config.renderOnInventory()) {
+                removeInfoBox();
+                overlayManager.add(overlay);
+                updateOverlays();
+            } else {
+                overlayManager.remove(overlay);
+                addInfoBox();
+            }
+        }
+    }
 
-	@Provides
-	InventoryCountConfig provideConfig(ConfigManager configManager)
-	{
-		return configManager.getConfig(InventoryCountConfig.class);
-	}
+    @Provides
+    InventoryCountConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(InventoryCountConfig.class);
+    }
 
-	private void addInfoBox()
-	{
-		inventoryCountInfoBox = new InventoryCountInfoBox(INVENTORY_IMAGE, this);
-		updateOverlays();
-		infoBoxManager.addInfoBox(inventoryCountInfoBox);
-	}
+    private void addInfoBox() {
+        inventoryCountInfoBox = new InventoryCountInfoBox(INVENTORY_IMAGE, this);
+        updateOverlays();
+        infoBoxManager.addInfoBox(inventoryCountInfoBox);
+    }
 
-	private void removeInfoBox()
-	{
-		infoBoxManager.removeInfoBox(inventoryCountInfoBox);
-		inventoryCountInfoBox = null;
-	}
+    private void removeInfoBox() {
+        infoBoxManager.removeInfoBox(inventoryCountInfoBox);
+        inventoryCountInfoBox = null;
+    }
 
-	private void updateOverlays()
-	{
-		clientThread.invoke(() -> {
-			String text = String.valueOf(openInventorySpaces());
-			if (config.renderOnInventory())
-			{
-				overlay.setText(text);
-			}
-			else
-			{
-				inventoryCountInfoBox.setText(text);
-			}
-		});
-	}
+    private void updateOverlays() {
+        clientThread.invoke(() -> {
+            String text = String.valueOf(openInventorySpaces());
+            if (config.renderOnInventory()) {
+                overlay.setText(text);
+            } else {
+                inventoryCountInfoBox.setText(text);
+            }
+        });
+    }
 
-	private int openInventorySpaces()
-	{
-		ItemContainer container = client.getItemContainer(InventoryID.INVENTORY);
-		Item[] items = container == null ? new Item[0] : container.getItems();
-		int usedSpaces = (int) Arrays.stream(items).filter(p -> p.getId() != -1).count();
-		return INVENTORY_SIZE - usedSpaces;
-	}
+    private int openInventorySpaces() {
+        ItemContainer container = client.getItemContainer(InventoryID.INVENTORY);
+        Item[] items = container == null ? new Item[0] : container.getItems();
+        int usedSpaces = (int) Arrays.stream(items).filter(p -> p.getId() != -1).count();
+        return INVENTORY_SIZE - usedSpaces;
+    }
 
-	@Subscribe
-	public void onItemContainerChanged(ItemContainerChanged event)
-	{
-		if (event.getContainerId() == InventoryID.INVENTORY.getId())
-		{
-			updateOverlays();
-		}
-	}
+    @Subscribe
+    public void onItemContainerChanged(ItemContainerChanged event) {
+        if (event.getContainerId() == InventoryID.INVENTORY.getId()) {
+            updateOverlays();
+        }
+    }
 }

--- a/src/main/java/io/robrichardson/inventorycount/InventoryOverlayTextPositions.java
+++ b/src/main/java/io/robrichardson/inventorycount/InventoryOverlayTextPositions.java
@@ -1,0 +1,7 @@
+package io.robrichardson.inventorycount;
+
+public enum InventoryOverlayTextPositions {
+    Top,
+    Center,
+    Bottom
+}


### PR DESCRIPTION
Implements a suggested feature allowing users to configure the following attributes of the inventory icon overlay:

- Position (Dropdown selection: Top, Center, Bottom)
  - Bottom by default
- Color (User selection via RGB)
  - White by default
- Outline (Boolean toggle to add an outline to the text)
  - False by default

## Defaults Options
![image](https://github.com/user-attachments/assets/73d6acae-b7f9-40f7-a155-5d7e8480fb48)

## Default Overlay with Outline Enabled
![image](https://github.com/user-attachments/assets/c813c02d-7c44-4b9b-85aa-de03f22945d5)

## User Selected Overlay Color
![image](https://github.com/user-attachments/assets/60a64cda-78a7-449d-9b33-4d977b72d83d)
![image](https://github.com/user-attachments/assets/b14f107a-3191-4f7a-af45-ce12e6434d25)

## Different Overlay Positions:
### Top
![image](https://github.com/user-attachments/assets/f87c80fe-2c53-4f58-a868-1f50456e465a)
### Center
![image](https://github.com/user-attachments/assets/b2907d86-f8f9-4dbe-8f59-97a6052c7b0c)
### Bottom (default)
![image](https://github.com/user-attachments/assets/ca8b3871-3977-408f-95bf-f136dc48201a)
